### PR TITLE
Fix bugs in split sequences

### DIFF
--- a/transformer_deid/tokenization.py
+++ b/transformer_deid/tokenization.py
@@ -1,11 +1,29 @@
 from bisect import bisect_left, bisect_right
 import logging
+import signal
+from contextlib import contextmanager
 import numpy as np
 import copy
 from typing import List, Optional, Union, TextIO
 
 from tqdm import tqdm
 from transformer_deid.label import Label
+
+
+class TimeoutException(Exception): pass
+
+@contextmanager
+def time_limit(seconds):
+    def signal_handler(signum, frame):
+        raise TimeoutException("Timed out!")
+
+    signal.signal(signal.SIGALRM, signal_handler)
+    signal.alarm(seconds)
+    try:
+        yield
+    finally:
+        signal.alarm(0)
+
 
 class DuplicateFilter(logging.Filter):
     def filter(self, record):
@@ -120,33 +138,36 @@ def split_sequences(tokenizer, texts, labels=None, ids=None):
     logger.info('Determining offsets for splitting long segments.')
     for i, encoded in tqdm(enumerate(encodings.encodings),
                            total=len(encodings.encodings)):
-        offsets = [o[0] for o in encoded.offsets]
-        token_sw = [False] + [
-            encoded.word_ids[i + 1] == encoded.word_ids[i]
-            for i in range(len(encoded.word_ids) - 1)
-        ]
-        # iterate through text and add create new subsets of the text
-        start = 0
-        subseq = []
-        while start < len(offsets):
-            # ensure we do not start on a sub-word token
-            while token_sw[start]:
-                start -= 1
+        with time_limit(10):
+            offsets = [o[0] for o in encoded.offsets]
+            token_sw = [False] + [
+                encoded.word_ids[i + 1] == encoded.word_ids[i]
+                for i in range(len(encoded.word_ids) - 1)
+            ]
+            # iterate through text and add create new subsets of the text
+            start = 0
+            subseq = []
+            while start < len(offsets):
+                # ensure we do not start on a sub-word token
+                while token_sw[start]:
+                    start -= 1
 
-            stop = start + seq_len
-            if stop < len(offsets):
-                # ensure we don't split sequences on a sub-word token
-                # do this by shortening the current sequence
-                while token_sw[stop]:
-                    stop -= 1
-            else:
-                # end the sub sequence at the end of the text
-                stop = len(offsets)
+                stop = start + seq_len
+                if stop < len(offsets):
+                    # ensure we don't split sequences on a sub-word token
+                    # do this by shortening the current sequence
+                    while token_sw[stop]:
+                        stop -= 1
+                else:
+                    # end the sub sequence at the end of the text
+                    stop = len(offsets)
 
-            subseq.append(start)
+                subseq.append(start)
 
-            # update start of next sequence to be end of current one
-            start = stop
+                # update start of next sequence to be end of current one
+                start = stop
+        except TimeoutException:
+            subseq = [0]
 
         sequence_offsets.append(subseq)
 

--- a/transformer_deid/tokenization.py
+++ b/transformer_deid/tokenization.py
@@ -126,13 +126,19 @@ def _compute_subseq(args):
     subseq = []
     max_iters = len(offsets) + 5
     iter_count = 0
+    last_stop = None
     while start < len(offsets):
         iter_count += 1
         if iter_count > max_iters:
+            true_count = sum(token_sw)
             logger.warning(
-                "Offset splitting exceeded max iterations (doc index %s, tokens=%s).",
+                "Offset splitting exceeded max iterations (doc index %s, tokens=%s, seq_len=%s, last_start=%s, last_stop=%s, subword_tokens=%s).",
                 index,
                 len(offsets),
+                seq_len,
+                start,
+                last_stop,
+                true_count,
             )
             break
         while token_sw[start]:
@@ -153,6 +159,7 @@ def _compute_subseq(args):
             stop = min(len(offsets), start + seq_len)
 
         subseq.append(start)
+        last_stop = stop
         start = stop
     duration = time.perf_counter() - start_time
     return {"index": index, "subseq": subseq, "token_count": len(offsets), "duration_s": duration}

--- a/transformer_deid/tokenization.py
+++ b/transformer_deid/tokenization.py
@@ -248,8 +248,11 @@ def encodings_to_label_list(pred_entities, encoding, id2label=None):
         else:
             logger.error(f'Passed predictions are of type {type(pred_entities[0])}, which is unsupported.')
 
-    last_word_id = next(x for x in reversed(encoding.word_ids)
-                        if x is not None)
+    try:
+        last_word_id = next(x for x in reversed(encoding.word_ids)
+                            if x is not None)
+    except StopIteration:
+        last_word_id = 0
 
     for word_id in range(last_word_id):
         # all indices corresponding to the same word

--- a/transformer_deid/tokenization.py
+++ b/transformer_deid/tokenization.py
@@ -117,7 +117,9 @@ def _compute_subseq(args):
     start_time = time.perf_counter()
     token_sw = [False]
     token_sw += [
-        word_ids[i + 1] == word_ids[i]
+        (word_ids[i + 1] is not None) and
+        (word_ids[i] is not None) and
+        (word_ids[i + 1] == word_ids[i])
         for i in range(len(word_ids) - 1)
     ]
     start = 0
@@ -141,14 +143,14 @@ def _compute_subseq(args):
         stop = start + seq_len
         if stop < len(offsets):
             while token_sw[stop]:
-                if stop == 0:
+                if stop <= start:
                     break
                 stop -= 1
         else:
             stop = len(offsets)
 
         if stop <= start:
-            stop = min(len(offsets), start + 1)
+            stop = min(len(offsets), start + seq_len)
 
         subseq.append(start)
         start = stop

--- a/transformer_deid/tokenization.py
+++ b/transformer_deid/tokenization.py
@@ -138,34 +138,35 @@ def split_sequences(tokenizer, texts, labels=None, ids=None):
     logger.info('Determining offsets for splitting long segments.')
     for i, encoded in tqdm(enumerate(encodings.encodings),
                            total=len(encodings.encodings)):
-        with time_limit(10):
-            offsets = [o[0] for o in encoded.offsets]
-            token_sw = [False] + [
-                encoded.word_ids[i + 1] == encoded.word_ids[i]
-                for i in range(len(encoded.word_ids) - 1)
-            ]
-            # iterate through text and add create new subsets of the text
-            start = 0
-            subseq = []
-            while start < len(offsets):
-                # ensure we do not start on a sub-word token
-                while token_sw[start]:
-                    start -= 1
-
-                stop = start + seq_len
-                if stop < len(offsets):
-                    # ensure we don't split sequences on a sub-word token
-                    # do this by shortening the current sequence
-                    while token_sw[stop]:
-                        stop -= 1
-                else:
-                    # end the sub sequence at the end of the text
-                    stop = len(offsets)
-
-                subseq.append(start)
-
-                # update start of next sequence to be end of current one
-                start = stop
+        try:
+            with time_limit(10):
+                offsets = [o[0] for o in encoded.offsets]
+                token_sw = [False] + [
+                    encoded.word_ids[i + 1] == encoded.word_ids[i]
+                    for i in range(len(encoded.word_ids) - 1)
+                ]
+                # iterate through text and add create new subsets of the text
+                start = 0
+                subseq = []
+                while start < len(offsets):
+                    # ensure we do not start on a sub-word token
+                    while token_sw[start]:
+                        start -= 1
+    
+                    stop = start + seq_len
+                    if stop < len(offsets):
+                        # ensure we don't split sequences on a sub-word token
+                        # do this by shortening the current sequence
+                        while token_sw[stop]:
+                            stop -= 1
+                    else:
+                        # end the sub sequence at the end of the text
+                        stop = len(offsets)
+    
+                    subseq.append(start)
+    
+                    # update start of next sequence to be end of current one
+                    start = stop
         except TimeoutException:
             subseq = [0]
 

--- a/transformer_deid/tokenization.py
+++ b/transformer_deid/tokenization.py
@@ -139,7 +139,7 @@ def split_sequences(tokenizer, texts, labels=None, ids=None):
     for i, encoded in tqdm(enumerate(encodings.encodings),
                            total=len(encodings.encodings)):
         try:
-            with time_limit(10):
+            with time_limit(30):
                 offsets = [o[0] for o in encoded.offsets]
                 token_sw = [False] + [
                     encoded.word_ids[i + 1] == encoded.word_ids[i]
@@ -168,6 +168,7 @@ def split_sequences(tokenizer, texts, labels=None, ids=None):
                     # update start of next sequence to be end of current one
                     start = stop
         except TimeoutException:
+            logger.warning("Offset calculation exceeded 30s; falling back to unsplit sequence for index %s.", i)
             subseq = [0]
 
         sequence_offsets.append(subseq)


### PR DESCRIPTION
Splitting was taking place on a single core, maxing out until a timeout (10s) was hit for each record, so no splitting was taking place. This has been fixed